### PR TITLE
Update host of Liveblog staging environment

### DIFF
--- a/components/haproxy/haproxy.cfg
+++ b/components/haproxy/haproxy.cfg
@@ -231,14 +231,14 @@ backend liveblog_3_api
     server zeit-api.liveblog.pro zeit-api.liveblog.pro:443 ssl sni str(zeit-api.liveblog.pro) check-sni zeit-api.liveblog.pro check inter 10s fastinter 5s rise 2 fall 3
 
 backend liveblog_staging_content
-    option httpchk GET /lb-release350/blogs/5c347bd7f077cc00e846fc96/index.html HTTP/1.1\r\nHost:\ superdesk-test.s3-eu-west-1.amazonaws.com
-    http-request set-header Host superdesk-test.s3-eu-west-1.amazonaws.com
-    http-request set-path %[path,regsub(^/liveblog/staging/content/health-check,/lb-release350/blogs/5c347bd7f077cc00e846fc96/index.html)]
-    http-request set-path %[path,regsub(^/liveblog/staging/content,/lb-release350/blogs)]
-    server superdesk-test.s3-eu-west-1.amazonaws.com superdesk-test.s3-eu-west-1.amazonaws.com:443 ssl check inter 10s fastinter 5s rise 2 fall 3
+    option httpchk GET /lb-test/blogs/5dd3ff3dbed0ef4d2e7edb0c/index.html HTTP/1.1\r\nHost:\ test.liveblog.pro
+    http-request set-header Host test.liveblog.pro
+    http-request set-path %[path,regsub(^/liveblog/staging/content/health-check,/lb-test/blogs/5dd3ff3dbed0ef4d2e7edb0c/index.html)]
+    http-request set-path %[path,regsub(^/liveblog/staging/content,/lb-test/blogs)]
+    server test.liveblog.pro test.liveblog.pro:443 ssl check inter 10s fastinter 5s rise 2 fall 3
 
 backend liveblog_staging_api
-    option httpchk GET /api HTTP/1.1\r\nHost:\ lb-release350.test.superdesk.org
-    http-request set-header Host lb-release350.test.superdesk.org
+    option httpchk GET /api HTTP/1.1\r\nHost:\ test.liveblog.pro
+    http-request set-header Host test.liveblog.pro
     http-request set-path %[path,regsub(^/liveblog/staging/api,/api)]
-    server lb-release350.test.superdesk.org lb-release350.test.superdesk.org:443 ssl check inter 10s fastinter 5s rise 2 fall 3
+    server test.liveblog.pro test.liveblog.pro:443 ssl check inter 10s fastinter 5s rise 2 fall 3


### PR DESCRIPTION
Für den Inhalt funktionieren die neuen Adressen: `curl -I https://test.liveblog.pro/lb-test/blogs/5dd3ff3dbed0ef4d2e7edb0c/index.html`

Für die API grundsätzlich au, zumindest gibt es eine Antwort 403 (statt 404): `curl -I https://test.liveblog.pro/lb-test/api`.

Die API-Authentifizierung kriege ich nicht getestet. Müsste sowas sein wie `curl https://test.liveblog.pro/lb-test/api/auth_db --header "Content-Type: application/json" --request POST --data '{\"username\":\"admin\",\"password\":\"admin\"}'`, aber das funktioniert nicht. Ich komm gerade nicht dahinter was falsch sein könnte, aber grundsätzlich ist die HostäNderung richtig und nur auf Staging (also sicher).