### PR TITLE
MAINT: Test revalidation on server error

### DIFF
--- a/components/varnish/component.py
+++ b/components/varnish/component.py
@@ -15,6 +15,10 @@ class Varnish(Component):
         self += Directory('vcl_includes')
 
         self += File(
+            "vcl_includes/acl.vcl",
+            source="vcl_includes/acl.vcl",
+            is_template="true")
+        self += File(
             "vcl_includes/backends.vcl",
             source="vcl_includes/backends.vcl",
             is_template="true")

--- a/components/varnish/default.vcl
+++ b/components/varnish/default.vcl
@@ -1,4 +1,6 @@
 vcl 4.0;
 
+import std;
+
 include "/etc/varnish/vcl_includes/backends.vcl";
 include "/etc/varnish/vcl_includes/main.vcl";

--- a/components/varnish/vcl_includes/acl.vcl
+++ b/components/varnish/vcl_includes/acl.vcl
@@ -1,0 +1,13 @@
+acl zeit {
+    "127.0.0.1";        # localhost
+    "10.100.0.0"/16;    # Server HH
+    "10.30.0.0"/21;     # ZON HH
+    "10.30.8.0"/21;     # ZON Ber
+    "10.200.200.0"/21;  # OpenVPN
+    "10.210.0.0"/21;    # OpenVPN
+    "10.110.0.0"/16;    # Google k8s ("GKE staging", eigentlich 10.110.16.0/20)
+    "10.111.48.0"/20;   # Google k8s production (siehe terraform-ops/.../production/gke.tf)
+    "10.111.32.0"/20;   # Google k8s staging (siehe terraform-ops/.../staging/gke-ip-masq-agent.tf)
+    "194.77.156.0"/23;  # ZON HH public
+    "217.13.68.0"/23;   # Gaertner
+}

--- a/components/varnish/vcl_includes/backend_response.vcl
+++ b/components/varnish/vcl_includes/backend_response.vcl
@@ -1,7 +1,12 @@
 sub vcl_backend_response {
     set beresp.http.x-req-url = bereq.url;
 
-    if (beresp.ttl <= 30s) {
+    # Per RFC2616 14.9, s-maxage is an option of the Cache-control header. But
+    # since we do not want to affect any other proxies or clients, just our own
+    # varnish, zeit.web uses a custom header instead.
+    if (beresp.http.x-maxage && beresp.status <= 302) {
+        set beresp.ttl = std.duration(beresp.http.x-maxage + "s", 60s);
+    } else if (beresp.ttl <= 30s) {
         set beresp.ttl = 30s;
     }
 
@@ -15,6 +20,10 @@ sub vcl_backend_response {
     if (bereq.http.x-long-term-grace == "true") {
         set beresp.grace = 48h;
     }
+
+    # Only for varnishtest
+    set beresp.http.x-beresp-ttl = beresp.ttl;
+    set beresp.http.x-beresp-grace = beresp.grace;
 
     if (beresp.status >= 500 && bereq.is_bgfetch) {
          return (abandon);

--- a/components/varnish/vcl_includes/deliver.vcl
+++ b/components/varnish/vcl_includes/deliver.vcl
@@ -1,3 +1,16 @@
 sub vcl_deliver {
+    # Add debug output (set in vcl_hit/miss/pass)
     set resp.http.X-ZON-Cache = req.http.X-ZON-Cache;
+    if (client.ip ~ zeit) {
+        if (req.http.X-ZON-TTL) {
+            set resp.http.X-ZON-TTL = req.http.X-ZON-TTL;
+        }
+        if (req.http.X-ZON-Grace) {
+            set resp.http.X-ZON-Grace = req.http.X-ZON-Grace;
+        }
+    } else {
+        # Remove for non-varnishtest (set in vcl_backend_response)
+        unset resp.http.x-beresp-ttl;
+        unset resp.http.x-beresp-grace;
+    }
 }

--- a/components/varnish/vcl_includes/hit_miss_pass.vcl
+++ b/components/varnish/vcl_includes/hit_miss_pass.vcl
@@ -1,5 +1,7 @@
 sub vcl_hit {
     set req.http.X-ZON-Cache = "HIT";
+    set req.http.X-ZON-TTL = obj.ttl;
+    set req.http.X-ZON-Grace = obj.grace;
 }
 
 sub vcl_miss {

--- a/components/varnish/vcl_includes/main.vcl
+++ b/components/varnish/vcl_includes/main.vcl
@@ -1,3 +1,4 @@
+include "/etc/varnish/vcl_includes/acl.vcl";
 include "/etc/varnish/vcl_includes/recv.vcl";
 include "/etc/varnish/vcl_includes/backend_response.vcl";
 include "/etc/varnish/vcl_includes/synth.vcl";

--- a/components/varnish/vcl_includes/test.vcl
+++ b/components/varnish/vcl_includes/test.vcl
@@ -1,3 +1,4 @@
 vcl 4.0;
+import std;
 
 include "/etc/varnish/vcl_includes/main.vcl";

--- a/components/varnishtest/tests/stale.vtc
+++ b/components/varnishtest/tests/stale.vtc
@@ -1,0 +1,69 @@
+varnishtest "Deliver from grace, if backend responds with server error"
+
+
+server s1 {
+    rxreq
+    expect req.url == "/hp-feed/zett"
+    expect req.http.Cookie == <undef>
+    txresp -hdr "X-Backend: haproxy-1" -hdr "x-maxage: 1"
+    accept
+
+    rxreq
+    expect req.url == "/hp-feed/zett"
+    expect req.http.Cookie == <undef>
+    txresp -status 500 -hdr "X-Backend: haproxy-failed" -hdr "x-maxage: 1"
+    accept
+
+    rxreq
+    expect req.url == "/hp-feed/zett"
+    expect req.http.Cookie == <undef>
+    txresp -hdr "X-Backend: haproxy-2" -hdr "x-maxage: 1"
+    accept
+
+} -start
+
+@ call varnish(['haproxy'])
+    include "/etc/varnish/vcl_includes/test.vcl";
+@ endcall
+
+
+# First request is served from backend directly, because there cannot be a hit.
+client c1 {
+    txreq -url "/hp-feed/zett" \
+          -hdr "Host: app-cache.zeit.de"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.x-backend == "haproxy-1"
+    expect resp.http.x-beresp-ttl == "1.000"
+    expect resp.http.x-beresp-grace == "3600.000"
+}-run
+
+delay 2
+
+# The second request is served stale while cache is being revalidated.
+client c2 {
+    txreq -url "/hp-feed/zett" \
+          -hdr "Host: app-cache.zeit.de"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.x-backend == "haproxy-1"
+} -run
+
+# The third request is still served stale, because the previous revalidation
+# failed. Revalidation is triggered again.
+client c3 {
+    txreq -url "/hp-feed/zett" \
+          -hdr "Host: app-cache.zeit.de"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.x-backend == "haproxy-1"
+} -run
+
+# The fourth request is a HIT with a positive TTL, because revalidation finally succeeded.
+client c4 {
+    txreq -url "/hp-feed/zett" \
+          -hdr "Host: app-cache.zeit.de"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.x-backend == "haproxy-2"
+} -run


### PR DESCRIPTION
Es brauchte noch einen Test für die Verwerfung eines Backend-Fetch, wenn das Ergebnis ein Serverfehler war. 