### PR TITLE
Change ACL to allow external IP instead of internal VPC network

### DIFF
--- a/components/haproxy/component.py
+++ b/components/haproxy/component.py
@@ -26,7 +26,7 @@ class HAProxy(Component):
         "194.77.156.0/23",  # ZON HH public
         "217.13.68.0/23",   # Gaertner
         "192.168.0.0/16",   # Docker
-        "10.156.0.0/20",    # Data Team GCP
+        "34.89.176.195/32", # Data Team GCP VM
     ]
 
     # We hard-code this here, but it comes from zeit-letsencrypt-acme.sh recipe


### PR DESCRIPTION
The Data Team project is not part of our shared VPC and thus not routed through our IPSec Tunnel. Add public IP to ACL instead of VPC network.