### PR TITLE
ZON-6336: Add "Wirtschaftwoche" feed to vcl, vtc etc

### DIFF
--- a/components/haproxy/haproxy.cfg
+++ b/components/haproxy/haproxy.cfg
@@ -159,6 +159,9 @@ frontend app-cache
     acl url_brandeins path_beg /hp-feed/brandeins
     use_backend brandeins if url_brandeins
 
+    acl url_wirtschaftswoche path_beg /hp-feed/wirtschaftswoche
+    use_backend wirtschaftswoche if url_wirtschaftswoche
+
     acl url_zett path_beg /hp-feed/zett
     use_backend zett if url_zett
 
@@ -171,6 +174,12 @@ backend brandeins
     http-request set-header Host www.brandeins.de
     http-request set-path %[path,regsub(^/hp-feed/brandeins,/zeit-feed.rss)]
     server www.brandeins.de www.brandeins.de:443 ssl check inter 10s fastinter 5s rise 2 fall 3
+
+backend wirtschaftswoche
+    option httpchk GET /contentexport/feed/rss/zeit-parkett HTTP/1.1\r\nHost:\ www.wiwo.de
+    http-request set-header Host www.wiwo.de
+    http-request set-path %[path,regsub(^/hp-feed/wirtschaftswoche,/contentexport/feed/rss/zeit-parkett)]
+    server www.wiwo.de www.wiwo.de:443 ssl check inter 10s fastinter 5s rise 2 fall 3
 
 backend community_app
     option httpchk GET /agatho/health_check HTTP/1.1\r\nHost:\ community{{component.subdomain}}.zeit.de

--- a/components/varnish/vcl_includes/recv.vcl
+++ b/components/varnish/vcl_includes/recv.vcl
@@ -35,6 +35,12 @@ sub vcl_recv {
         set req.http.x-long-term-grace = "true";
     }
 
+    if (req.url == "/wirtschaftswoche-hp-feed") {
+        set req.url = "/hp-feed/wirtschaftswoche";
+        set req.http.x-ignore-cache-control = "true";
+        set req.http.x-long-term-grace = "true";
+    }
+
     if (req.url == "/zett-hp-feed") {
         set req.url = "/hp-feed/zett";
         set req.http.x-ignore-cache-control = "true";

--- a/components/varnishtest/tests/wirtschaftswoche.vtc
+++ b/components/varnishtest/tests/wirtschaftswoche.vtc
@@ -1,0 +1,28 @@
+varnishtest "Content for wirtschaftswoche is delivered and cached"
+
+
+server s1 {
+    rxreq
+    expect req.url == "/hp-feed/wirtschaftswoche"
+    expect req.http.Cookie == <undef>
+    txresp -hdr "X-Backend: haproxy"
+} -start
+
+@ call varnish(['haproxy'])
+    include "/etc/varnish/vcl_includes/test.vcl";
+@ endcall
+
+client c1 {
+    txreq -url "/wirtschaftswoche-hp-feed" -hdr "Host: app-cache.zeit.de" \
+        -hdr "Cookie: foo"
+    rxresp
+    expect resp.http.X-Backend == "haproxy"
+} -run
+
+varnish v1 -expect cache_miss == 1
+varnish v1 -expect cache_hit == 0
+
+client c1 -run
+
+varnish v1 -expect cache_miss == 1
+varnish v1 -expect cache_hit == 1

--- a/test/integration/batou-app-cache/hp_feed_spec.rb
+++ b/test/integration/batou-app-cache/hp_feed_spec.rb
@@ -16,6 +16,15 @@ control "brandeins feed is proxied correctly" do
 end
 
 
+control "wirtschaftswoche feed is proxied correctly" do
+  describe http("http://localhost/wirtschaftswoche-hp-feed",
+                enable_remote_worker: true) do
+    its("status") { should eq 200}
+    its("body") { should include "<link>http://www.wiwo.de</link>" }
+  end
+end
+
+
 control "zett feed is proxied correctly" do
   describe http("http://localhost/zett-hp-feed",
                 enable_remote_worker: true) do


### PR DESCRIPTION
Für https://vivi.(staging.)zeit.de/repository/data/cp-automatic-feeds.xml

Ganz naiv copy&paste von brandeins. Ich glaube, das ist gerechtfertigt

(siehe [ZON-6336](https://zeit-online.atlassian.net/browse/ZON-6336))